### PR TITLE
Removed unneeded Fabric API dependency and made villagers save their jobs over corruption

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,16 +20,12 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	//modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// Config
-	modImplementation ("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
-    	exclude(group: "net.fabricmc.fabric-api")
-  	}
+	modImplementation ("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}")
 	// Modmenu
-	modCompileOnly modRuntimeOnly("com.terraformersmc:modmenu:${project.mod_menu_version}"),{
-		exclude(group: "net.fabricmc.fabric-api")
-	}
+	modCompileOnly modRuntimeOnly("com.terraformersmc:modmenu:${project.mod_menu_version}")
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
 	minecraft_version=1.19
-	yarn_mappings=1.19+build.1
+	yarn_mappings=1.19+build.4
 	loader_version=0.14.7
 
 # Mod Properties
@@ -13,6 +13,6 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = villagerfix
 
 # Dependencies
-	fabric_version=0.55.2+1.19
+	#fabric_version=0.55.2+1.19
 	cloth_config_version=7.0.69
 	mod_menu_version=4.0.0

--- a/src/main/java/net/villagerfix/access/VillagerAccess.java
+++ b/src/main/java/net/villagerfix/access/VillagerAccess.java
@@ -1,8 +1,19 @@
 package net.villagerfix.access;
 
 import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.village.TradeOfferList;
+
+import java.util.List;
 
 public interface VillagerAccess {
 
-    public void saveLastJob(VillagerEntity villagerEntity);
+    void saveLastJob(VillagerEntity villagerEntity);
+
+    void setJobList(List<String> jobList);
+
+    void setOffersList(List<TradeOfferList> offersList);
+
+    List<String> getJobList();
+
+    List<TradeOfferList> getOffersList();
 }

--- a/src/main/java/net/villagerfix/mixin/LoseJobOnSiteLossTaskMixin.java
+++ b/src/main/java/net/villagerfix/mixin/LoseJobOnSiteLossTaskMixin.java
@@ -14,7 +14,7 @@ import net.villagerfix.access.VillagerAccess;
 public class LoseJobOnSiteLossTaskMixin {
 
     @Inject(method = "run", at = @At("HEAD"))
-    protected void runMixin(ServerWorld serverWorld, VillagerEntity villagerEntity, long l, CallbackInfo info) {
+    private void runMixin(ServerWorld serverWorld, VillagerEntity villagerEntity, long l, CallbackInfo info) {
         ((VillagerAccess) villagerEntity).saveLastJob(villagerEntity);
     }
 

--- a/src/main/java/net/villagerfix/mixin/VillagerEntityMixin.java
+++ b/src/main/java/net/villagerfix/mixin/VillagerEntityMixin.java
@@ -25,8 +25,8 @@ import net.villagerfix.access.VillagerAccess;
 @Mixin(VillagerEntity.class)
 public abstract class VillagerEntityMixin extends MerchantEntity implements VillagerAccess {
 
-    private List<TradeOfferList> offerList = new ArrayList<TradeOfferList>();
-    private List<String> jobList = new ArrayList<String>();
+    private List<TradeOfferList> offerList = new ArrayList<>();
+    private List<String> jobList = new ArrayList<>();
 
     public VillagerEntityMixin(EntityType<? extends MerchantEntity> entityType, World world) {
         super(entityType, world);
@@ -110,5 +110,25 @@ public abstract class VillagerEntityMixin extends MerchantEntity implements Vill
             offerList.add(villagerEntity.getOffers());
             jobList.add(villagerEntity.getVillagerData().getProfession().toString());
         }
+    }
+
+    @Override
+    public void setJobList(List<String> jobList) {
+        this.jobList = jobList;
+    }
+
+    @Override
+    public void setOffersList(List<TradeOfferList> offersList) {
+        this.offerList = offersList;
+    }
+
+    @Override
+    public List<String> getJobList() {
+        return this.jobList;
+    }
+
+    @Override
+    public List<TradeOfferList> getOffersList() {
+        return this.offerList;
     }
 }

--- a/src/main/java/net/villagerfix/mixin/ZombieEntityMixin.java
+++ b/src/main/java/net/villagerfix/mixin/ZombieEntityMixin.java
@@ -1,0 +1,23 @@
+package net.villagerfix.mixin;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.ZombieEntity;
+import net.minecraft.entity.mob.ZombieVillagerEntity;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.villagerfix.access.VillagerAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+@Mixin(ZombieEntity.class)
+public abstract class ZombieEntityMixin {
+
+    @Inject(method = "onKilledOther", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/mob/ZombieVillagerEntity;setOfferData(Lnet/minecraft/nbt/NbtCompound;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void villagerTradeFix$saveDataToZombieVillagerEntity(ServerWorld world, LivingEntity other, CallbackInfoReturnable<Boolean> cir, boolean bl, VillagerEntity villagerEntity, ZombieVillagerEntity zombieVillagerEntity) {
+        ((VillagerAccess)zombieVillagerEntity).setOffersList(((VillagerAccess)other).getOffersList());
+        ((VillagerAccess)zombieVillagerEntity).setJobList(((VillagerAccess)other).getJobList());
+    }
+}

--- a/src/main/java/net/villagerfix/mixin/ZombieVillagerEntityMixin.java
+++ b/src/main/java/net/villagerfix/mixin/ZombieVillagerEntityMixin.java
@@ -1,0 +1,57 @@
+package net.villagerfix.mixin;
+
+import net.minecraft.entity.mob.ZombieVillagerEntity;
+import net.minecraft.entity.passive.VillagerEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.village.TradeOfferList;
+import net.villagerfix.access.VillagerAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.List;
+
+@Mixin(ZombieVillagerEntity.class)
+public abstract class ZombieVillagerEntityMixin implements VillagerAccess {
+
+    private List<TradeOfferList> offerList;
+    private List<String> jobList;
+
+    @Inject(method = "finishConversion", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/passive/VillagerEntity;setExperience(I)V"), locals = LocalCapture.CAPTURE_FAILSOFT)
+    private void villagerTradeFix$setVillagerData(ServerWorld world, CallbackInfo ci, VillagerEntity villagerEntity) {
+        ((VillagerAccess)villagerEntity).setOffersList(this.offerList);
+        ((VillagerAccess)villagerEntity).setJobList(this.jobList);
+    }
+
+    @Inject(method = "writeCustomDataToNbt", at = @At("TAIL"))
+    private void villagerTradeFix$saveDataToNbt(NbtCompound nbt, CallbackInfo ci) {
+        for (int i = 0; i < this.jobList.size(); ++i) {
+            String jobString = "OldOffer" + i;
+            nbt.put(jobString, this.offerList.get(i).toNbt());
+            nbt.putString(jobString + "OldWork", this.jobList.get(i));
+        }
+        nbt.putInt("JobCount", this.jobList.size());
+    }
+
+    @Inject(method = "readCustomDataFromNbt", at = @At("TAIL"))
+    private void villagerTradeFix$readDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
+        for (int i = 0; i < nbt.getInt("JobCount"); ++i) {
+            String jobString = "OldOffer" + i;
+            this.jobList.add(nbt.getString(jobString + "OldWork"));
+            if (nbt.contains(jobString, 10))
+                this.offerList.add(new TradeOfferList(nbt.getCompound(jobString)));
+        }
+    }
+
+    @Override
+    public void setOffersList(List<TradeOfferList> offerList) {
+        this.offerList = offerList;
+    }
+
+    public void setJobList(List<String> jobList) {
+        this.jobList = jobList;
+    }
+}

--- a/src/main/java/net/villagerfix/mixin/ZombieVillagerEntityMixin.java
+++ b/src/main/java/net/villagerfix/mixin/ZombieVillagerEntityMixin.java
@@ -51,6 +51,7 @@ public abstract class ZombieVillagerEntityMixin implements VillagerAccess {
         this.offerList = offerList;
     }
 
+    @Override
     public void setJobList(List<String> jobList) {
         this.jobList = jobList;
     }

--- a/src/main/resources/villagerfix.mixins.json
+++ b/src/main/resources/villagerfix.mixins.json
@@ -5,7 +5,9 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "LoseJobOnSiteLossTaskMixin",
-    "VillagerEntityMixin"
+    "VillagerEntityMixin",
+    "ZombieEntityMixin",
+    "ZombieVillagerEntityMixin"
   ],
   "client": [],
   "injectors": {


### PR DESCRIPTION
Hi, I made a similar mod to yours a while ago without realizing yours exists. Looking through it, 2 things stood out to me.
1, that your implementation required the Fabric API, which confused me as my implementation does not and I couldn't find anything in your code that utilized it either.
and 2, that you had no code allowing the saved jobs to remain after a villager has been zombified and cured. This is something I found in my mod a bit after release and patched.
So since your mod was bigger, I decided to try and fix these in your environment for your mod.

In regards to the mod in general, while I think some of parts of my code are cleaner and more efficient, so long as you continue to maintain your mod, I'll cease maintaining mine. 